### PR TITLE
Improve frontend README and streaming chat

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_OPENAI_API_KEY=your-openai-api-key
+NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,30 @@
-### Front End
+# 🎨 Vibe Chat Frontend
 
-Please populate this README with instructions on how to run the application!
+Welcome to the shiny frontend for your AI Engineer Challenge! This app is built with **Next.js**, so you can run it locally and deploy it straight to Vercel.
+
+## Getting Started
+
+1. **Install dependencies**
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. **Add your OpenAI key**
+   - Copy `.env.local.example` to `.env.local` and replace the placeholder with your real API key.
+   - The same file can also define `NEXT_PUBLIC_BACKEND_URL` if your FastAPI backend is running somewhere other than `localhost:8000`.
+3. **Run the dev server**
+   ```bash
+   npm run dev
+   ```
+   Visit `http://localhost:3000` to chat with your backend. Make sure the FastAPI server in `/api` is running (`python api/app.py`).
+
+## Deployment
+
+This directory works with the provided `vercel.json` file. Once everything looks good locally, deploy with:
+
+```bash
+vercel --prod
+```
+
+Happy vibe‑coding! 🎉
+

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'standalone'
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ai-engineer-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+
+export default function Home() {
+  const [userMessage, setUserMessage] = useState('');
+  const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const sendMessage = async () => {
+    if (!userMessage) return;
+
+    // add the user's message and a placeholder assistant message
+    setMessages([...messages, { role: 'user', content: userMessage }, { role: 'assistant', content: '' }]);
+    setUserMessage('');
+    setLoading(true);
+
+    const base = process.env.NEXT_PUBLIC_BACKEND_URL || '';
+    const res = await fetch(`${base}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        developer_message: 'You are a helpful assistant.',
+        user_message: userMessage,
+        model: 'gpt-4.1-mini',
+        api_key: process.env.NEXT_PUBLIC_OPENAI_API_KEY
+      })
+    });
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let done = false;
+    let assistantMessage = '';
+
+    while (!done) {
+      const { value, done: doneReading } = await reader.read();
+      done = doneReading;
+      assistantMessage += decoder.decode(value);
+      setMessages(prev => {
+        const updated = [...prev];
+        // update the last message (assistant)
+        updated[updated.length - 1] = { role: 'assistant', content: assistantMessage };
+        return updated;
+      });
+    }
+
+    setLoading(false);
+  };
+
+  return (
+    <main style={{ fontFamily: 'sans-serif', maxWidth: 600, margin: '0 auto', padding: '2rem' }}>
+      <h1>Vibe Chat</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        {messages.map((msg, idx) => (
+          <p key={idx}><strong>{msg.role}:</strong> {msg.content}</p>
+        ))}
+      </div>
+      <input
+        type="text"
+        value={userMessage}
+        onChange={(e) => setUserMessage(e.target.value)}
+        placeholder="Ask something..."
+        style={{ width: '100%', padding: '0.5rem' }}
+      />
+      <button onClick={sendMessage} disabled={loading} style={{ marginTop: '0.5rem' }}>
+        {loading ? 'Sending...' : 'Send'}
+      </button>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- elaborate README with backend instructions and env config
- update example environment file with backend URL
- stream assistant messages in the chat UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68499ee4eea8832cb632fb8938ca8d23