### PR TITLE
Allow user to input API key

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,3 +1,4 @@
-NEXT_PUBLIC_OPENAI_API_KEY=your-openai-api-key
+# Optional: set the backend URL if not running on localhost
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
+# Users enter their OpenAI key in the app UI
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,9 +9,9 @@ Welcome to the shiny frontend for your AI Engineer Challenge! This app is built 
    cd frontend
    npm install
    ```
-2. **Add your OpenAI key**
-   - Copy `.env.local.example` to `.env.local` and replace the placeholder with your real API key.
-   - The same file can also define `NEXT_PUBLIC_BACKEND_URL` if your FastAPI backend is running somewhere other than `localhost:8000`.
+2. **Configure environment (optional)**
+   - Copy `.env.local.example` to `.env.local` if you need to change `NEXT_PUBLIC_BACKEND_URL`.
+   - The app now lets users provide their own OpenAI API key directly in the interface, so you don't need to store it in this file.
 3. **Run the dev server**
    ```bash
    npm run dev

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -4,6 +4,7 @@ export default function Home() {
   const [userMessage, setUserMessage] = useState('');
   const [messages, setMessages] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [apiKey, setApiKey] = useState('');
 
   const sendMessage = async () => {
     if (!userMessage) return;
@@ -21,7 +22,7 @@ export default function Home() {
         developer_message: 'You are a helpful assistant.',
         user_message: userMessage,
         model: 'gpt-4.1-mini',
-        api_key: process.env.NEXT_PUBLIC_OPENAI_API_KEY
+        api_key: apiKey || process.env.NEXT_PUBLIC_OPENAI_API_KEY
       })
     });
 
@@ -48,6 +49,13 @@ export default function Home() {
   return (
     <main style={{ fontFamily: 'sans-serif', maxWidth: 600, margin: '0 auto', padding: '2rem' }}>
       <h1>Vibe Chat</h1>
+      <input
+        type="password"
+        value={apiKey}
+        onChange={(e) => setApiKey(e.target.value)}
+        placeholder="OpenAI API Key"
+        style={{ width: '100%', padding: '0.5rem', marginBottom: '1rem' }}
+      />
       <div style={{ marginBottom: '1rem' }}>
         {messages.map((msg, idx) => (
           <p key={idx}><strong>{msg.role}:</strong> {msg.content}</p>


### PR DESCRIPTION
## Summary
- add an input box so end users can supply their OpenAI API key
- use the provided key when calling the backend
- update documentation to explain the new flow

## Testing
- `python -m py_compile api/app.py`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849a4781b04832cb2df60472d3e440b