### PR TITLE
Add retro Ask Jeeves theme

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,5 +26,5 @@ This directory works with the provided `vercel.json` file. Once everything looks
 vercel --prod
 ```
 
-Happy vibe‑coding! 🎉
+Happy vibe‑coding! 🎉 The interface now sports a nostalgic Ask Jeeves theme for extra retro flair.
 

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import '../styles/askjeeves.css';
 
 export default function Home() {
   const [userMessage, setUserMessage] = useState('');
@@ -46,24 +47,25 @@ export default function Home() {
   };
 
   return (
-    <main style={{ fontFamily: 'sans-serif', maxWidth: 600, margin: '0 auto', padding: '2rem' }}>
-      <h1>Vibe Chat</h1>
-      <div style={{ marginBottom: '1rem' }}>
-        {messages.map((msg, idx) => (
-          <p key={idx}><strong>{msg.role}:</strong> {msg.content}</p>
-        ))}
-      </div>
-      <input
-        type="text"
-        value={userMessage}
-        onChange={(e) => setUserMessage(e.target.value)}
-        placeholder="Ask something..."
-        style={{ width: '100%', padding: '0.5rem' }}
-      />
-      <button onClick={sendMessage} disabled={loading} style={{ marginTop: '0.5rem' }}>
-        {loading ? 'Sending...' : 'Send'}
-      </button>
-    </main>
+    <>
+      <header>Ask Jeeves Chat</header>
+      <main>
+        <div style={{ marginBottom: '1rem' }}>
+          {messages.map((msg, idx) => (
+            <p key={idx}><strong>{msg.role}:</strong> {msg.content}</p>
+          ))}
+        </div>
+        <input
+          type="text"
+          value={userMessage}
+          onChange={(e) => setUserMessage(e.target.value)}
+          placeholder="Ask Jeeves..."
+        />
+        <button onClick={sendMessage} disabled={loading}>
+          {loading ? 'Sending...' : 'Ask'}
+        </button>
+      </main>
+    </>
   );
 }
 

--- a/frontend/styles/askjeeves.css
+++ b/frontend/styles/askjeeves.css
@@ -1,0 +1,43 @@
+body {
+  background-color: #f5f5f5;
+  font-family: "Times New Roman", serif;
+  color: #000;
+}
+
+header {
+  background-color: #6600cc;
+  color: white;
+  padding: 1rem;
+  text-align: center;
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+main {
+  background-color: #ffffff;
+  border: 1px solid #ccc;
+  width: 80%;
+  margin: 2rem auto;
+  padding: 2rem;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+input {
+  border: 2px solid #666;
+  padding: 0.5rem;
+  width: 100%;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+
+button {
+  background-color: #f0d400;
+  border: 2px solid #666;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.5;
+}


### PR DESCRIPTION
## Summary
- add Ask Jeeves themed styling
- import new styles in index page
- update frontend README with note about new look

## Testing
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden for next package)*

------
https://chatgpt.com/codex/tasks/task_e_6849a499eab4832c8853b2f4c4c73705