### PR TITLE
Move global styles into Next.js _app

### DIFF
--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/askjeeves.css';
+
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import '../styles/askjeeves.css';
 
 export default function Home() {
   const [userMessage, setUserMessage] = useState('');


### PR DESCRIPTION
## Summary
- fix Next.js build failure by moving CSS import to `_app.js`

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849a754b40c832c9bd3ccbed6e9c066